### PR TITLE
add "clean*" tasks as dependencies of task "clean"

### DIFF
--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaccPlugin.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaccPlugin.java
@@ -3,6 +3,7 @@ package ca.coglinc.gradle.plugins.javacc;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -44,5 +45,10 @@ public class JavaccPlugin implements Plugin<Project> {
         options.put(Task.TASK_GROUP, group);
 
         project.task(options, name);
+
+        Task cleanTask = project.getTasks().findByName("clean");
+        if (cleanTask != null) {
+            cleanTask.dependsOn("clean" + StringUtils.capitalize(CompileJavaccTask.TASK_NAME_VALUE));
+        }
     }
 }


### PR DESCRIPTION
Gradle has a rule that a task called "clean<NameOfTask>" clears the output
of the task "<nameOfTask>". However, by default these task-specific
cleaners are not executed when running "gradle clean". It doesn't matter
as long as a custom task's output directory is in the project's default
build directory, but if that's not the case, the outputs won't be
cleaned unless you specifically request it.

This commit makes it so that the task "clean", if defined in the project
at the moment of the javacc plugin application, is set to depend on the
cleaner counterparts of the tasks generated by this plugin. This way, even if
the generated source directory is moved out of the project's build
directory, it still gets cleaned when the user runs "gradle clean".