### PR TITLE
Use Matcher.quoteReplacement to make acceptanceTest successful.

### DIFF
--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFile.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFile.java
@@ -109,7 +109,7 @@ public class CompiledJavaccFile {
         logger.info("Not copying compiled file {} from {} to {} because it is overridden by the custom AST class {}", compiledJavaccFile, outputDirectory, targetDirectory,
             getCustomAstClassInputFile(sourceTree));
         
-        String packagePath = getPackageName(compiledJavaccFile).replaceAll("\\.", File.separator);
+        String packagePath = getPackageName(compiledJavaccFile).replaceAll(Matcher.quoteReplacement("\\."), File.separator);
         File destination = new File(targetDirectory.getAbsolutePath() + File.separator + packagePath, compiledJavaccFile.getName());
         logger.info("Copying custom AST class [{}] to [{}]", getCustomAstClassInputFile(sourceTree), destination);
         


### PR DESCRIPTION
Otherwise, one gets
```
javacc.compilation.ThePluginCompilesJavaccToExpectedDirectoryStory > givenASimpleProjectWithCustomAstClassesWhenRerunCompileJavaccTaskThenTheFilesThatDoNotHaveACorrespondingCustomAstClassAreGeneratedInTheDefaultDirectory FAILED
    org.gradle.testkit.runner.UnexpectedBuildFailure at ThePluginCompilesJavaccToExpectedDirectoryStory.java:341

javacc.compilation.ThePluginCompilesJavaccToExpectedDirectoryStory > givenASimpleProjectWithCustomAstClassesWhenExecuteCompileJavaccTaskThenTheFilesThatDoNotHaveACorrespondingCustomAstClassAreGeneratedInTheDefaultDirectory FAILED
    org.gradle.testkit.runner.UnexpectedBuildFailure at ThePluginCompilesJavaccToExpectedDirectoryStory.java:309

27 tests completed, 2 failed
:javacc-gradle-plugin:acceptanceTest FAILED
```