### PR TITLE
Support of the JavaCC C++ generated code

### DIFF
--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.SourceTask;
 
 public abstract class AbstractJavaccTask extends SourceTask {
     protected Map<String, String> programArguments;
+    protected Language language = Language.Java;
 
     private File inputDirectory;
     private File outputDirectory;
@@ -79,6 +80,15 @@ public abstract class AbstractJavaccTask extends SourceTask {
 
         return this;
     }
+
+	public void setLanguage(Language language) {
+		this.language = language;
+	}
+
+    @Internal
+    protected Language getLanguage() {
+		return language;
+	}
 
     @Internal
     protected Configuration getClasspath() {

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
@@ -32,7 +32,7 @@ public class CompileJavaccTask extends AbstractJavaccTask {
         JavaccProgramInvoker javaccInvoker = new JavaccProgramInvoker(getProject(), getClasspath(), inputOutputDirectories.getTempOutputDirectory());
         ProgramArguments arguments = new ProgramArguments();
         arguments.addAll(getArguments());
-        SourceFileCompiler compiler = new JavaccSourceFileCompiler(javaccInvoker, arguments, inputOutputDirectories, getLogger());
+        SourceFileCompiler compiler = new JavaccSourceFileCompiler(language, javaccInvoker, arguments, inputOutputDirectories, getLogger());
 
         compiler.createTempOutputDirectory();
         compiler.compileSourceFilesToTempOutputDirectory();

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjdocTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjdocTask.java
@@ -32,7 +32,7 @@ public class CompileJjdocTask extends AbstractJavaccTask {
         JjdocProgramInvoker jjdocInvoker = new JjdocProgramInvoker(getProject(), getClasspath(), inputOutputDirectories.getTempOutputDirectory());
         ProgramArguments arguments = new ProgramArguments();
         arguments.addAll(getArguments());
-        SourceFileCompiler compiler = new JavaccSourceFileCompiler(jjdocInvoker, arguments, inputOutputDirectories, getLogger());
+        SourceFileCompiler compiler = new JavaccSourceFileCompiler(language, jjdocInvoker, arguments, inputOutputDirectories, getLogger());
 
         compiler.createTempOutputDirectory();
         compiler.compileSourceFilesToTempOutputDirectory();

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjtreeTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjtreeTask.java
@@ -32,7 +32,7 @@ public class CompileJjtreeTask extends AbstractJavaccTask {
         JjtreeProgramInvoker jjtreeInvoker = new JjtreeProgramInvoker(getProject(), getClasspath(), inputOutputDirectories.getTempOutputDirectory());
         ProgramArguments arguments = new ProgramArguments();
         arguments.addAll(getArguments());
-        SourceFileCompiler compiler = new JavaccSourceFileCompiler(jjtreeInvoker, arguments, inputOutputDirectories, getLogger());
+        SourceFileCompiler compiler = new JavaccSourceFileCompiler(language, jjtreeInvoker, arguments, inputOutputDirectories, getLogger());
 
         compiler.createTempOutputDirectory();
         compiler.compileSourceFilesToTempOutputDirectory();

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaToJavaccDependencyAction.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaToJavaccDependencyAction.java
@@ -4,55 +4,85 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.language.cpp.tasks.CppCompile;
 
 public class JavaToJavaccDependencyAction implements Action<Project> {
 
-    @Override
-    public void execute(Project project) {
-        if (!project.getPlugins().hasPlugin("java")) {
-            return;
-        }
+	@Override
+	public void execute(Project project) {
+		if (project.getPlugins().hasPlugin("java") || project.getPlugins().hasPlugin("cpp")) {
+			configureCompileJJTreeTask(project);
+			configureCompileJavaccTask(project);
+		}
+	}
 
-        configureCompileJJTreeTask(project);
-        configureCompileJavaccTask(project);
-    }
+	private void configureCompileJJTreeTask(Project project) {
+		CompileJjtreeTask compileJjtreeTask = (CompileJjtreeTask) project.getTasks().findByName(CompileJjtreeTask.TASK_NAME_VALUE);
+		if (compileJjtreeTask == null) {
+			return;
+		}
 
-    private void configureCompileJJTreeTask(Project project) {
-        CompileJjtreeTask compileJjtreeTask = (CompileJjtreeTask) project.getTasks().findByName(CompileJjtreeTask.TASK_NAME_VALUE);
-        if (compileJjtreeTask == null) {
-            return;
-        }
+		if (!compileJjtreeTask.getSource().isEmpty()) {
+			if (project.getPlugins().hasPlugin("java"))
+				addJJTreeDependencyToJavaccCompileTask(project.getTasks().withType(JavaCompile.class), project.getTasks().withType(CompileJavaccTask.class),
+						compileJjtreeTask);
 
-        if (!compileJjtreeTask.getSource().isEmpty()) {
-            addJJTreeDependencyToJavaccCompileTask(project.getTasks().withType(JavaCompile.class),
-                project.getTasks().withType(CompileJavaccTask.class), compileJjtreeTask);
-        }
-    }
+			if (project.getPlugins().hasPlugin("cpp"))
+				addJJTreeDependencyToCppCompileTask(project.getTasks().withType(CppCompile.class), project.getTasks().withType(CompileJavaccTask.class),
+						compileJjtreeTask);
+		}
+	}
 
-    private void configureCompileJavaccTask(Project project) {
-        CompileJavaccTask compileJavaccTask = (CompileJavaccTask) project.getTasks().findByName(CompileJavaccTask.TASK_NAME_VALUE);
-        if (compileJavaccTask != null) {
-            addJavaccDependencyToJavaCompileTask(project.getTasks().withType(JavaCompile.class), compileJavaccTask);
-        }
-    }
+	private void configureCompileJavaccTask(Project project) {
+		CompileJavaccTask compileJavaccTask = (CompileJavaccTask) project.getTasks().findByName(CompileJavaccTask.TASK_NAME_VALUE);
+		if (compileJavaccTask != null) {
+			if (project.getPlugins().hasPlugin("java"))
+				addJavaccDependencyToJavaCompileTask(project.getTasks().withType(JavaCompile.class), compileJavaccTask);
 
-    private void addJavaccDependencyToJavaCompileTask(TaskCollection<JavaCompile> javaCompilationTasks, CompileJavaccTask compileJavaccTask) {
-        for (JavaCompile task : javaCompilationTasks) {
-            task.dependsOn(compileJavaccTask);
-            task.source(compileJavaccTask.getOutputDirectory());
-        }
-    }
+			if (project.getPlugins().hasPlugin("cpp"))
+				addJavaccDependencyToCppCompileTask(project.getTasks().withType(CppCompile.class), compileJavaccTask);
 
-    private void addJJTreeDependencyToJavaccCompileTask(TaskCollection<JavaCompile> javaCompilationTasks,
-        TaskCollection<CompileJavaccTask> javaccCompilationTasks, CompileJjtreeTask compileJjtreeTask) {
-        for (JavaCompile task : javaCompilationTasks) {
-            task.dependsOn(compileJjtreeTask);
-            task.source(compileJjtreeTask.getOutputDirectory());
-        }
+		}
+	}
 
-        for (CompileJavaccTask task : javaccCompilationTasks) {
-            task.dependsOn(compileJjtreeTask);
-            task.source(compileJjtreeTask.getOutputDirectory());
-        }
-    }
+	private void addJavaccDependencyToJavaCompileTask(TaskCollection<JavaCompile> javaCompilationTasks, CompileJavaccTask compileJavaccTask) {
+		for (JavaCompile task : javaCompilationTasks) {
+			task.dependsOn(compileJavaccTask);
+			task.source(compileJavaccTask.getOutputDirectory());
+		}
+	}
+
+	private void addJavaccDependencyToCppCompileTask(TaskCollection<CppCompile> cppCompilationTasks, CompileJavaccTask compileJavaccTask) {
+		for (CppCompile task : cppCompilationTasks) {
+			task.dependsOn(compileJavaccTask);
+			task.source(compileJavaccTask.getOutputDirectory());
+		}
+	}
+
+	private void addJJTreeDependencyToJavaccCompileTask(TaskCollection<JavaCompile> javaCompilationTasks, TaskCollection<CompileJavaccTask> javaccCompilationTasks,
+			CompileJjtreeTask compileJjtreeTask) {
+		for (JavaCompile task : javaCompilationTasks) {
+			task.dependsOn(compileJjtreeTask);
+			task.source(compileJjtreeTask.getOutputDirectory());
+		}
+
+		for (CompileJavaccTask task : javaccCompilationTasks) {
+			task.dependsOn(compileJjtreeTask);
+			task.source(compileJjtreeTask.getOutputDirectory());
+		}
+	}
+
+	private void addJJTreeDependencyToCppCompileTask(TaskCollection<CppCompile> cppCompilationTasks, TaskCollection<CompileJavaccTask> javaccCompilationTasks,
+			CompileJjtreeTask compileJJTreeTask) {
+
+		for (CppCompile task : cppCompilationTasks) {
+			task.dependsOn(compileJJTreeTask);
+			task.source(compileJJTreeTask.getOutputDirectory());
+		}
+
+		for (CompileJavaccTask task : javaccCompilationTasks) {
+			task.dependsOn(compileJJTreeTask);
+			task.source(compileJJTreeTask.getOutputDirectory());
+		}
+	}
 }

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/Language.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/Language.java
@@ -1,0 +1,5 @@
+package ca.coglinc.gradle.plugins.javacc;
+
+public enum Language {
+	Java, Cpp
+}

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFile.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFile.java
@@ -10,124 +10,164 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 public class CompiledJavaccFile {
-    private static final Pattern PACKAGE_DECLARATION_PATTERN = Pattern.compile("package\\s+([^\\s.;]+(\\.[^\\s.;]+)*)\\s*;");
+	private static final Pattern PACKAGE_DECLARATION_PATTERN = Pattern.compile("package\\s+([^\\s.;]+(\\.[^\\s.;]+)*)\\s*;");
 
-    private File compiledJavaccFile;
-    private File outputDirectory;
-    private FileTree customAstClassesDirectory;
-    private File targetDirectory;
-    private Logger logger;
+	private Language language;
+	private File compiledJavaccFile;
+	private File outputDirectory;
+	private FileTree customAstClassesDirectory;
+	private File targetDirectory;
+	private Logger logger;
 
-    CompiledJavaccFile(File file, File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
-        this.compiledJavaccFile = file;
-        this.outputDirectory = outputDirectory;
-        this.customAstClassesDirectory = customAstClassesDirectory;
-        this.targetDirectory = targetDirectory;
-        this.logger = logger;
-    }
+	CompiledJavaccFile(Language language, File file, File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+		this.language = language;
+		this.compiledJavaccFile = file;
+		this.outputDirectory = outputDirectory;
+		this.customAstClassesDirectory = customAstClassesDirectory;
+		this.targetDirectory = targetDirectory;
+		this.logger = logger;
+	}
 
-    public boolean customAstClassExists() {
-        return customAstClassExists(customAstClassesDirectory);
-    }
+	public boolean customAstClassExists() {
+		return customAstClassExists(customAstClassesDirectory);
+	}
 
-    public boolean customAstClassExists(FileTree fileTree) {
-        File customAstClassInputFile = getCustomAstClassInputFile(fileTree);
+	public boolean customAstClassExists(FileTree fileTree) {
+		File customAstClassInputFile = getCustomAstClassInputFile(fileTree);
 
-        return (customAstClassInputFile != null) && customAstClassInputFile.exists();
-    }
+		return (customAstClassInputFile != null) && customAstClassInputFile.exists();
+	}
 
-    private File getCustomAstClassInputFile(FileTree fileTree) {
-        String compiledJavaccFilePackage = getPackageName(compiledJavaccFile);
+	private File getCustomAstClassInputFile(FileTree fileTree) {
+		String compiledJavaccFilePackage = getPackageName(compiledJavaccFile);
 
-        if (fileTree != null) {
-            Collection<File> sourceFiles = fileTree.getFiles();
-            return scanSourceFiles(compiledJavaccFilePackage, sourceFiles);
-        } else {
-            return null;
-        }
-    }
+		if (fileTree != null) {
+			Collection<File> sourceFiles = fileTree.getFiles();
+			return scanSourceFiles(compiledJavaccFilePackage, sourceFiles);
+		} else {
+			return null;
+		}
+	}
 
-    private File scanSourceFiles(String compiledJavaccFilePackage, Collection<File> sourceFiles) {
-        for (File sourceFile : sourceFiles) {
-            logger.debug("Scanning source file [{}] looking for a file named [{}] in package [{}]", sourceFile, compiledJavaccFile.getName(), compiledJavaccFilePackage);
-            if (sourceFile.isDirectory()) {
-                Collection<File> childFiles = FileUtils.listFiles(sourceFile, FileFilterUtils.suffixFileFilter(".java"), TrueFileFilter.TRUE);
-                File matchingChildFile = scanSourceFiles(compiledJavaccFilePackage, childFiles);
-                if (matchingChildFile != null) {
-                    return matchingChildFile;
-                }
-            } else {
-                if (FilenameUtils.isExtension(sourceFile.getName(), "java") && compiledJavaccFile.getName().equals(sourceFile.getName())) {
-                    String packageName = getPackageName(sourceFile);
+	private File scanSourceFiles(String compiledJavaccFilePackage, Collection<File> sourceFiles) {
+		for (File sourceFile : sourceFiles) {
+			logger.debug("Scanning source file [{}] looking for a file named [{}] in package [{}]", sourceFile, compiledJavaccFile.getName(),
+					compiledJavaccFilePackage);
+			if (sourceFile.isDirectory()) {
+				Collection<File> childFiles = null;
+				IOFileFilter ioFilefilter = null;
+				if (language == Language.Java) {
+					ioFilefilter = FileFilterUtils.suffixFileFilter(".java");
+				} else if (language == Language.Cpp) {
+					IOFileFilter inclFilefilter = FileFilterUtils.suffixFileFilter(".h");
+					IOFileFilter codeFilefilter = FileFilterUtils.suffixFileFilter(".cc");
+					ioFilefilter = FileFilterUtils.or(inclFilefilter, codeFilefilter);
+				}
 
-                    if (compiledJavaccFilePackage.equals(packageName)) {
-                        return sourceFile;
-                    }
-                }
-            }
-        }
+				childFiles = FileUtils.listFiles(sourceFile, ioFilefilter, TrueFileFilter.TRUE);
+				File matchingChildFile = scanSourceFiles(compiledJavaccFilePackage, childFiles);
+				if (matchingChildFile != null) {
+					return matchingChildFile;
+				}
+			} else {
+				if (language == Language.Java) {
+					if (getSourceFile(sourceFile, "java") != null) {
+						String packageName = getPackageName(sourceFile);
+						if (compiledJavaccFilePackage.equals(packageName)) {
+							return sourceFile;
+						}
+					}
+				} else if (language == Language.Cpp) {
+					if (getSourceFile(sourceFile, "h") != null) {
+						String packageName = getPackageName(sourceFile);
+						if (compiledJavaccFilePackage.equals(packageName)) {
+							return sourceFile;
+						}
+					}
+					if (getSourceFile(sourceFile, "cc") != null) {
+						String packageName = getPackageName(sourceFile);
 
-        return null;
-    }
+						if (compiledJavaccFilePackage.equals(packageName)) {
+							return sourceFile;
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
 
-    private String getPackageName(File file) {
-        String fileContents = "";
-        try {
-            fileContents = FileUtils.readFileToString(file, Charsets.UTF_8.name());
-        } catch (IOException e) {
-            logger.warn("Could not read file contents for file [{}]", file);
-        }
+	private File getSourceFile(File sourceFile, String extension) {
+		if (FilenameUtils.isExtension(sourceFile.getName(), extension) && compiledJavaccFile.getName().equals(sourceFile.getName())) {
+			return sourceFile;
+		}
+		return null;
+	}
 
-        Matcher matcher = PACKAGE_DECLARATION_PATTERN.matcher(fileContents);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
+	private String getPackageName(File file) {
+		String fileContents = "";
+		try {
+			fileContents = FileUtils.readFileToString(file, Charsets.UTF_8.name());
+		} catch (IOException e) {
+			logger.warn("Could not read file contents for file [{}]", file);
+		}
 
-        return "";
-    }
+		Matcher matcher = PACKAGE_DECLARATION_PATTERN.matcher(fileContents);
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
 
-    public void copyCompiledFileToTargetDirectory() {
-        logger.info("Custom AST class not found");
+		return "";
+	}
 
-        File destination = new File(compiledJavaccFile.getAbsolutePath().replace(outputDirectory.getAbsolutePath(), targetDirectory.getAbsolutePath()));
-        logger.info("Copying compiled file {} to {}", compiledJavaccFile, destination);
+	public void copyCompiledFileToTargetDirectory() {
+		logger.info("Custom AST class not found");
 
-        try {
-            FileUtils.copyFile(compiledJavaccFile, destination);
-        } catch (IOException e) {
-            String errorMessage = String.format("Could not copy %s from %s to %s", compiledJavaccFile, outputDirectory, targetDirectory);
-            throw new CompiledJavaccFileOperationException(errorMessage, e);
-        }
-    }
+		File destination = new File(compiledJavaccFile.getAbsolutePath().replace(outputDirectory.getAbsolutePath(), targetDirectory.getAbsolutePath()));
+		logger.info("Copying compiled file {} to {}", compiledJavaccFile, destination);
 
-    public void copyCustomAstClassToTargetDirectory(FileTree sourceTree) {
-        logger.info("Not copying compiled file {} from {} to {} because it is overridden by the custom AST class {}", compiledJavaccFile, outputDirectory, targetDirectory,
-            getCustomAstClassInputFile(sourceTree));
+		try {
+			FileUtils.copyFile(compiledJavaccFile, destination);
+		} catch (IOException e) {
+			String errorMessage = String.format("Could not copy %s from %s to %s", compiledJavaccFile, outputDirectory, targetDirectory);
+			throw new CompiledJavaccFileOperationException(errorMessage, e);
+		}
+	}
 
-        String packagePath = getPackageName(compiledJavaccFile).replaceAll("\\.", Matcher.quoteReplacement(File.separator));
-        File destination = new File(targetDirectory.getAbsolutePath() + File.separator + packagePath, compiledJavaccFile.getName());
-        logger.info("Copying custom AST class [{}] to [{}]", getCustomAstClassInputFile(sourceTree), destination);
+	public void copyCustomAstClassToTargetDirectory(FileTree sourceTree) {
+		logger.info("Not copying compiled file {} from {} to {} because it is overridden by the custom AST class {}", compiledJavaccFile, outputDirectory,
+				targetDirectory, getCustomAstClassInputFile(sourceTree));
 
-        try {
-            FileUtils.copyFile(getCustomAstClassInputFile(sourceTree), destination);
-        } catch (IOException e) {
-            String errorMessage = String.format("Could not copy %s to %s", getCustomAstClassInputFile(sourceTree), targetDirectory);
-            throw new CompiledJavaccFileOperationException(errorMessage, e);
-        }
-    }
+		if (language == Language.Cpp) // do not copy any file for now
+			return;
 
-    public void ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTree(FileTree javaSourceTree) {
-        logger.info("Ignoring compiled file {} because it is overridden by the custom AST class in Java source tree {}", compiledJavaccFile,
-            getCustomAstClassInputFile(javaSourceTree));
-    }
+		String packagePath = getPackageName(compiledJavaccFile).replaceAll("\\.", Matcher.quoteReplacement(File.separator));
+		File destination = new File(targetDirectory.getAbsolutePath() + File.separator + packagePath, compiledJavaccFile.getName());
+		logger.info("Copying custom AST class [{}] to [{}]", getCustomAstClassInputFile(sourceTree), destination);
 
-    @Override
-    public String toString() {
-        return compiledJavaccFile.getAbsolutePath();
-    }
+		try {
+			FileUtils.copyFile(getCustomAstClassInputFile(sourceTree), destination);
+		} catch (IOException e) {
+			String errorMessage = String.format("Could not copy %s to %s", getCustomAstClassInputFile(sourceTree), targetDirectory);
+			throw new CompiledJavaccFileOperationException(errorMessage, e);
+		}
+	}
+
+	public void ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTree(FileTree javaSourceTree) {
+		logger.info("Ignoring compiled file {} because it is overridden by the custom AST class in Java source tree {}", compiledJavaccFile,
+				getCustomAstClassInputFile(javaSourceTree));
+	}
+
+	@Override
+	public String toString() {
+		return compiledJavaccFile.getAbsolutePath();
+	}
 }

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectory.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectory.java
@@ -9,13 +9,17 @@ import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 
-public class CompiledJavaccFilesDirectory {
-    private File outputDirectory;
-    private FileTree customAstClassesDirectory;
-    private File targetDirectory;
-    private Logger logger;
+import ca.coglinc.gradle.plugins.javacc.Language;
 
-    CompiledJavaccFilesDirectory(File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+public class CompiledJavaccFilesDirectory {
+	private final Language language;
+	private final File outputDirectory;
+    private final FileTree customAstClassesDirectory;
+    private final File targetDirectory;
+    private final Logger logger;
+
+    CompiledJavaccFilesDirectory(Language language, File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+        this.language = language;
         this.outputDirectory = outputDirectory;
         this.customAstClassesDirectory = customAstClassesDirectory;
         this.targetDirectory = targetDirectory;
@@ -27,7 +31,7 @@ public class CompiledJavaccFilesDirectory {
         Collection<CompiledJavaccFile> compiledJavaccFiles = new ArrayList<CompiledJavaccFile>();
         
         for (File file : files) {
-            CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+            CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
             compiledJavaccFiles.add(compiledJavaccFile);
         }
         

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryFactory.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryFactory.java
@@ -5,9 +5,11 @@ import java.io.File;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 public class CompiledJavaccFilesDirectoryFactory {
 
-    public CompiledJavaccFilesDirectory getCompiledJavaccFilesDirectory(File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+    public CompiledJavaccFilesDirectory getCompiledJavaccFilesDirectory(Language language, File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
         if ((outputDirectory == null) || !outputDirectory.exists() || !outputDirectory.isDirectory()) {
             throw new IllegalArgumentException("outputDirectory [" + outputDirectory + "] must be an existing directory");
         }
@@ -20,6 +22,6 @@ public class CompiledJavaccFilesDirectoryFactory {
             throw new IllegalArgumentException("targetDirectory [" + targetDirectory + "] must be an existing directory");
         }
         
-        return new CompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        return new CompiledJavaccFilesDirectory(language, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
     }
 }

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompiler.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompiler.java
@@ -9,6 +9,7 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.logging.Logger;
 
 import ca.coglinc.gradle.plugins.javacc.JavaccTaskException;
+import ca.coglinc.gradle.plugins.javacc.Language;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFile;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFilesDirectory;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFilesDirectoryFactory;
@@ -26,13 +27,15 @@ import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramInvoker;
  * </ul>
  */
 public class JavaccSourceFileCompiler implements SourceFileCompiler {
+	private final Language language;
     private final ProgramInvoker programInvoker;
     private final ProgramArguments argumentsProvidedByTask;
     private final CompilerInputOutputConfiguration configuration;
     private CompiledJavaccFilesDirectoryFactory compiledJavaccFilesDirectoryFactory = new CompiledJavaccFilesDirectoryFactory();
     private final Logger logger;
 
-    public JavaccSourceFileCompiler(ProgramInvoker programInvoker, ProgramArguments argumentsProvidedByTask, CompilerInputOutputConfiguration configuration, Logger logger) {
+    public JavaccSourceFileCompiler(Language language, ProgramInvoker programInvoker, ProgramArguments argumentsProvidedByTask, CompilerInputOutputConfiguration configuration, Logger logger) {
+        this.language = language;
         this.programInvoker = programInvoker;
         this.argumentsProvidedByTask = argumentsProvidedByTask;
         this.configuration = configuration;
@@ -82,7 +85,7 @@ public class JavaccSourceFileCompiler implements SourceFileCompiler {
     @Override
     public void copyCompiledFilesFromTempOutputDirectoryToOutputDirectory() {
         CompiledJavaccFilesDirectory compiledJavaccFilesDirectory = compiledJavaccFilesDirectoryFactory.getCompiledJavaccFilesDirectory(
-            configuration.getTempOutputDirectory(), configuration.getCompleteSourceTree(), getOutputDirectory(), getLogger());
+            language, configuration.getTempOutputDirectory(), configuration.getCompleteSourceTree(), getOutputDirectory(), getLogger());
 
         for (CompiledJavaccFile compiledJavaccFile : compiledJavaccFilesDirectory.listFiles()) {
             FileTree javaSourceTree = configuration.getJavaSourceTree();
@@ -131,7 +134,12 @@ public class JavaccSourceFileCompiler implements SourceFileCompiler {
         return logger;
     }
 
-    void setCompiledJavaccFilesDirectoryFactoryForTest(CompiledJavaccFilesDirectoryFactory factory) {
+	@Override
+	public Language getLanguage() {
+		return language;
+	}
+
+	void setCompiledJavaccFilesDirectoryFactoryForTest(CompiledJavaccFilesDirectoryFactory factory) {
         compiledJavaccFilesDirectoryFactory = factory;
     }
 }

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/NonJavaccSourceFileVisitor.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/NonJavaccSourceFileVisitor.java
@@ -8,6 +8,7 @@ import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileVisitDetails;
 
 import ca.coglinc.gradle.plugins.javacc.JavaccTaskException;
+import ca.coglinc.gradle.plugins.javacc.Language;
 
 /**
  * This implementation of {@link org.gradle.api.file.FileVisitor} visits only files that are not supported by the provided {@code compiler}.
@@ -21,6 +22,9 @@ class NonJavaccSourceFileVisitor extends EmptyFileVisitor {
 
     @Override
     public void visitFile(FileVisitDetails fileDetails) {
+        if (compiler.getLanguage() == Language.Cpp)
+        	return;
+
         if (!isValidSourceFileForTask(fileDetails)) {
             File sourceFile = fileDetails.getFile();
             File destinationFile = new File(sourceFile.getAbsolutePath().replace(compiler.getInputDirectory().getAbsolutePath(), compiler.getOutputDirectory().getAbsolutePath()));
@@ -32,6 +36,8 @@ class NonJavaccSourceFileVisitor extends EmptyFileVisitor {
     private void copyFile(File sourceFile, File destinationFile) {
         compiler.getLogger().debug("Copying non javacc source file from {} to {}", sourceFile.getAbsolutePath(), destinationFile.getAbsolutePath());
 
+        if (compiler.getLanguage() == Language.Cpp)
+        	return;
         try {
             FileUtils.copyFile(sourceFile, destinationFile);
         } catch (IOException e) {

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/SourceFileCompiler.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/compiler/SourceFileCompiler.java
@@ -5,6 +5,8 @@ import java.io.File;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.logging.Logger;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 /**
  * Implementations invoke a program to compile source files.
  *
@@ -33,4 +35,6 @@ public interface SourceFileCompiler {
     void createTempOutputDirectory();
 
     void cleanTempOutputDirectory();
+
+    Language getLanguage();
 }

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/JavaToJavaccDependencyActionTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/JavaToJavaccDependencyActionTest.java
@@ -16,6 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mockito;
+import org.mockito.internal.verification.Times;
+import org.mockito.verification.VerificationMode;
 
 public class JavaToJavaccDependencyActionTest {
     private JavaccPlugin plugin;
@@ -171,7 +173,11 @@ public class JavaToJavaccDependencyActionTest {
 
         action.execute(project);
 
-        Mockito.verify(project).getPlugins();
+        Mockito.verify(project, times(2)).getPlugins();
         Mockito.verifyNoMoreInteractions(project);
     }
+
+	private VerificationMode times(int i) {
+		return new Times(i);
+	}
 }

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFileTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFileTest.java
@@ -28,9 +28,12 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FileUtils.class)
 public class CompiledJavaccFileTest {
+    private Language language = Language.Java;
     private File outputDirectory;
     private FileTree customAstClassesDirectory;
     private File targetDirectory;
@@ -57,7 +60,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassDoesNotExist() {
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         boolean customAstClassExists = compiledJavaccFile.customAstClassExists();
         
@@ -67,7 +70,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassExists() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         boolean customAstClassExists = compiledJavaccFile.customAstClassExists();
         
@@ -77,7 +80,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassDoesNotExistInSpecificDirectory() {
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         boolean customAstClassExists = compiledJavaccFile.customAstClassExists(customAstClassesDirectory);
         
@@ -87,7 +90,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassExistsInSpecificDirectory() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         boolean customAstClassExists = compiledJavaccFile.customAstClassExists(customAstClassesDirectory);
         
@@ -97,7 +100,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassCantExistInNullDirectory() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         boolean customAstClassExists = compiledJavaccFile.customAstClassExists(null);
         
@@ -110,7 +113,7 @@ public class CompiledJavaccFileTest {
         assertFalse(expectedFile.exists());
         
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         compiledJavaccFile.copyCompiledFileToTargetDirectory();
         
@@ -120,7 +123,7 @@ public class CompiledJavaccFileTest {
     @Test(expected = CompiledJavaccFileOperationException.class)
     public void copyCompiledFileToTargetDirectoryFails() {
         File file = new File(outputDirectory, "DoesNotExist.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         compiledJavaccFile.copyCompiledFileToTargetDirectory();
     }
@@ -131,7 +134,7 @@ public class CompiledJavaccFileTest {
         assertFalse(expectedFile.exists());
         
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         compiledJavaccFile.copyCustomAstClassToTargetDirectory(customAstClassesDirectory);
         
@@ -145,7 +148,7 @@ public class CompiledJavaccFileTest {
         FileUtils.copyFile(any(File.class), any(File.class));
         
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         compiledJavaccFile.copyCustomAstClassToTargetDirectory(customAstClassesDirectory);
     }
@@ -153,7 +156,7 @@ public class CompiledJavaccFileTest {
     @Test
     public void toStringReturnsAbsoluteFileName() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         String stringValue = compiledJavaccFile.toString();
         
@@ -164,7 +167,7 @@ public class CompiledJavaccFileTest {
     public void ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTreeOnlyLogsThatCompiledFileIsNotActedUpon() {
         File file = mock(File.class);
         FileTree javaSourceTree = mock(FileTree.class);
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(language, file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
         
         compiledJavaccFile.ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTree(javaSourceTree);
         

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryFactoryTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryFactoryTest.java
@@ -12,7 +12,10 @@ import org.gradle.api.file.FileTree;
 import org.junit.Before;
 import org.junit.Test;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 public class CompiledJavaccFilesDirectoryFactoryTest {
+    private Language language = Language.Java;
     private CompiledJavaccFilesDirectoryFactory factory;
     private File outputDirectory;
     private FileTree customAstClassesDirectory;
@@ -32,51 +35,51 @@ public class CompiledJavaccFilesDirectoryFactoryTest {
 
     @Test
     public void createInstance() {
-        CompiledJavaccFilesDirectory directory = factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, targetDirectory, null);
+        CompiledJavaccFilesDirectory directory = factory.getCompiledJavaccFilesDirectory(language, outputDirectory, customAstClassesDirectory, targetDirectory, null);
         
         assertNotNull(directory);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(null, customAstClassesDirectory, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, null, customAstClassesDirectory, targetDirectory, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustExist() {
         File inexistingOutputDirectory = new File(getClass().getResource("/").getFile() + "doesNotExist");
         
-        factory.getCompiledJavaccFilesDirectory(inexistingOutputDirectory, customAstClassesDirectory, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, inexistingOutputDirectory, customAstClassesDirectory, targetDirectory, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustBeADirectory() {
         File invalidOutputDirectory = new File(getClass().getResource("/javacc/input/JavaccOutputTest.jj").getFile());
         
-        factory.getCompiledJavaccFilesDirectory(invalidOutputDirectory, customAstClassesDirectory, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, invalidOutputDirectory, customAstClassesDirectory, targetDirectory, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void customAstClassesDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, null, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, outputDirectory, null, targetDirectory, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, null, null);
+        factory.getCompiledJavaccFilesDirectory(language, outputDirectory, customAstClassesDirectory, null, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustExist() {
         File inexistingOutputDirectory = new File(getClass().getResource("/").getFile() + "doesNotExist");
         
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, inexistingOutputDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, outputDirectory, customAstClassesDirectory, inexistingOutputDirectory, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustBeADirectory() {
         File invalidOutputDirectory = new File(getClass().getResource("/javacc/input/JavaccOutputTest.jj").getFile());
         
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, invalidOutputDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(language, outputDirectory, customAstClassesDirectory, invalidOutputDirectory, null);
     }
 }

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compilationresults/CompiledJavaccFilesDirectoryTest.java
@@ -11,11 +11,14 @@ import java.util.Collection;
 
 import org.junit.Test;
 
+import ca.coglinc.gradle.plugins.javacc.Language;
+
 public class CompiledJavaccFilesDirectoryTest {
+    private Language language = Language.Java;
 
     @Test
     public void listFilesReturnsEmptyCollectionForEmptyDirectory() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/empty").getFile()), null, null, null);
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(language, new File(getClass().getResource("/empty").getFile()), null, null, null);
         
         Collection<CompiledJavaccFile> files = directory.listFiles();
         
@@ -24,7 +27,7 @@ public class CompiledJavaccFilesDirectoryTest {
     
     @Test
     public void listFilesReturnsAllFiles() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResults").getFile()), null, null, null);
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(language, new File(getClass().getResource("/compiledResults").getFile()), null, null, null);
         
         Collection<CompiledJavaccFile> files = directory.listFiles();
         
@@ -34,7 +37,7 @@ public class CompiledJavaccFilesDirectoryTest {
     
     @Test
     public void listFilesReturnsAllFilesRecursively() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResultsWithSubFolders").getFile()), null, null, null);
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(language, new File(getClass().getResource("/compiledResultsWithSubFolders").getFile()), null, null, null);
         
         Collection<CompiledJavaccFile> files = directory.listFiles();
         
@@ -45,7 +48,7 @@ public class CompiledJavaccFilesDirectoryTest {
     @Test
     public void toStringReturnsAbsoluteDirectoryPath() {
         File outputDirectory = new File(getClass().getResource("/compiledResults").getFile());
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(outputDirectory, null, null, null);
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(language, outputDirectory, null, null, null);
         
         String stringValue = directory.toString();
         

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompilerTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompilerTest.java
@@ -168,7 +168,7 @@ public class JavaccSourceFileCompilerTest {
         when(compiledFilesDirectory.listFiles()).thenReturn(Arrays.asList(compiledFile));
 
         CompiledJavaccFilesDirectoryFactory factory = mock(CompiledJavaccFilesDirectoryFactory.class);
-        when(factory.getCompiledJavaccFilesDirectory(language, any(File.class), any(FileTree.class), any(File.class), any(Logger.class))).thenReturn(compiledFilesDirectory);
+        when(factory.getCompiledJavaccFilesDirectory(any(Language.class), any(File.class), any(FileTree.class), any(File.class), any(Logger.class))).thenReturn(compiledFilesDirectory);
 
         ((JavaccSourceFileCompiler) compiler).setCompiledJavaccFilesDirectoryFactoryForTest(factory);
     }

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompilerTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/compiler/JavaccSourceFileCompilerTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 import ca.coglinc.gradle.plugins.javacc.JavaccTaskException;
+import ca.coglinc.gradle.plugins.javacc.Language;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFile;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFilesDirectory;
 import ca.coglinc.gradle.plugins.javacc.compilationresults.CompiledJavaccFilesDirectoryFactory;
@@ -37,6 +38,7 @@ import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramArguments;
 import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramInvoker;
 
 public class JavaccSourceFileCompilerTest {
+    private Language language = Language.Java;
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -64,7 +66,7 @@ public class JavaccSourceFileCompilerTest {
         compilerInputOutputConfiguration = givenCompilerConfiguration(source);
         logger = givenLogger();
 
-        compiler = new JavaccSourceFileCompiler(programInvoker, programArguments, compilerInputOutputConfiguration, logger);
+        compiler = new JavaccSourceFileCompiler(language, programInvoker, programArguments, compilerInputOutputConfiguration, logger);
     }
 
     private ProgramArguments givenProgramArguments() {
@@ -166,7 +168,7 @@ public class JavaccSourceFileCompilerTest {
         when(compiledFilesDirectory.listFiles()).thenReturn(Arrays.asList(compiledFile));
 
         CompiledJavaccFilesDirectoryFactory factory = mock(CompiledJavaccFilesDirectoryFactory.class);
-        when(factory.getCompiledJavaccFilesDirectory(any(File.class), any(FileTree.class), any(File.class), any(Logger.class))).thenReturn(compiledFilesDirectory);
+        when(factory.getCompiledJavaccFilesDirectory(language, any(File.class), any(FileTree.class), any(File.class), any(Logger.class))).thenReturn(compiledFilesDirectory);
 
         ((JavaccSourceFileCompiler) compiler).setCompiledJavaccFilesDirectoryFactoryForTest(factory);
     }


### PR DESCRIPTION
Hi John

This PR provides the support of the generation of JavaCC tool for the C++ target. There is a new script variable named 'language' defaulted to Language.Java. Thus all code & tests for the Java generation are identical to your latest master.