### PR TITLE
Change initial capacity of options Hashmap

### DIFF
--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaccPlugin.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/JavaccPlugin.java
@@ -60,7 +60,7 @@ public class JavaccPlugin implements Plugin<Project> {
     }
 
     private void addTaskToProject(Project project, Class<? extends AbstractJavaccTask> type, String name, String description, String group, Configuration configuration) {
-        Map<String, Object> options = new HashMap<String, Object>(2);
+        Map<String, Object> options = new HashMap<String, Object>(3);
 
         options.put(Task.TASK_TYPE, type);
         options.put(Task.TASK_DESCRIPTION, description);


### PR DESCRIPTION
This is a minor change that changes the initial capacity of a hashmap so there won't be a need for a rehashing operation.

Although three entries are added to the `options` hashmap, the initial capacity is set to two.